### PR TITLE
Remove Camel Quarkus from the Ecosystem CI

### DIFF
--- a/camel-quarkus/info.yaml
+++ b/camel-quarkus/info.yaml
@@ -1,4 +1,0 @@
-url: https://github.com/ppalaga/camel-quarkus # Github repo of your extension
-issues:
-  repo: quarkusio/quarkus # this should be left as is when CI updates are going to be reported on the Quarkus repository
-  latestCommit: 8646 # this is the number of the issue you created above


### PR DESCRIPTION
This reverts commit 649378e8498f26c400ddfa79d0523c795117b03a.