### PR TITLE
Enable batch mode to avoid a too verbose output

### DIFF
--- a/quarkus-ecosystem-test
+++ b/quarkus-ecosystem-test
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-mvn --settings .github/quarkus-ecosystem-maven-settings.xml clean install -Dquarkus.version=${QUARKUS_VERSION} -Dversion.io.quarkus=${QUARKUS_VERSION} -Dnative -Dquarkus.native.container-build=true
+mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B clean install -Dquarkus.version=${QUARKUS_VERSION} -Dversion.io.quarkus=${QUARKUS_VERSION} -Dnative -Dquarkus.native.container-build=true


### PR DESCRIPTION
Logs are barely usable on GitHub right now. This will improve the
situation a bit.