### PR TITLE
Install latest JBang

### DIFF
--- a/setup-and-test
+++ b/setup-and-test
@@ -63,8 +63,9 @@ sudo apt-get update -o Dir::Etc::sourcelist="sources.list" \
 sudo apt-get install -y gnupg2 gnupg-agent
 echo "Installing SDKMAN"
 curl -s "https://get.sdkman.io" | bash
+echo sdkman_auto_answer=true > ~/.sdkman/etc/config
 source ~/.sdkman/bin/sdkman-init.sh
-sdk install jbang 0.21.0
+sdk install jbang
 
 jbang .github/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="${TEST_STATUS}" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}"
 


### PR DESCRIPTION
Also makes SDKMan CI friendly.

See https://sdkman.io/usage#config

It also fixes the build problem: 
```bash
ᐅ sdk install jbang 0.21.0

Downloading: jbang 0.21.0

In progress...

####################################################################################################################################################################################### 100.0%
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /home/ggastald/.sdkman/archives/jbang-0.21.0.zip or
        /home/ggastald/.sdkman/archives/jbang-0.21.0.zip.zip, and cannot find /home/ggastald/.sdkman/archives/jbang-0.21.0.zip.ZIP, period.

Stop! The archive was corrupt and has been removed! Please try installing again.
```