### PR TITLE
Make SDKMan non interactive

### DIFF
--- a/setup-and-test
+++ b/setup-and-test
@@ -64,6 +64,7 @@ sudo apt-get install -y gnupg2 gnupg-agent
 echo "Installing SDKMAN"
 curl -s "https://get.sdkman.io" | bash
 source ~/.sdkman/bin/sdkman-init.sh
+sed -i -e 's/sdkman_auto_answer=false/sdkman_auto_answer=true/g' ~/.sdkman/etc/config
 sdk install jbang 0.50.1
 
 jbang .github/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="${TEST_STATUS}" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}"


### PR DESCRIPTION
I had an issue in the Quickstarts tests with SDKMan starting to ask questions. Let's silence it completely.