### PR TITLE
Make setup-and-test configurable

### DIFF
--- a/.github/workflows/ecosystem-action.yml
+++ b/.github/workflows/ecosystem-action.yml
@@ -47,6 +47,18 @@ jobs:
               yq w -i context.yaml quarkus.version "999-SNAPSHOT"
               yq w -i context.yaml quarkus.sha "${QUARKUS_SHA}"
 
+              # delete previous alternatives
+              yq d -i ecosystem-ci/kogito-quarkus/context.yaml alternatives
+              # if alternatives is set in info.yaml, then copy it to context.yaml
+              alts=$(yq r info.yaml alternatives)
+              if [ -n "${alts}" ]; then
+                echo "altenatives:" >> context.yaml
+                list=$(yq r info.yaml alternatives)
+                while IFS= read -r line; do
+                  echo "  $line" >> context.yaml
+                done <<< "$alts"
+              fi
+
               # commit changes
               git config --local user.email "quarkusbot@xam.dk"
               git config --local user.name "Quarkus Bot"

--- a/setup-and-test
+++ b/setup-and-test
@@ -2,15 +2,18 @@
 set -e
 
 cd ecosystem-ci/${ECOSYSTEM_CI_REPO_PATH}
-# if ISSUE_NUM was not specified, read it from the context file
-if [[ -z "${ISSUE_NUM}" ]]; then
+# if an alternative is not specified, then we just read the global info
+if [[ -z "${ALTERNATIVE}" ]]; then
   ISSUE_NUM=$(yq r ${ECOSYSTEM_CI_REPO_FILE} issues.latestCommit)
+  QUARKUS_SHA=$(yq r ${ECOSYSTEM_CI_REPO_FILE} quarkus.sha)
+else
+  ISSUE_NUM=$(yq r ${ECOSYSTEM_CI_REPO_FILE} alternatives.${ALTERNATIVE}.issue)
+  QUARKUS_BRANCH=$(yq r ${ECOSYSTEM_CI_REPO_FILE} alternatives.${ALTERNATIVE}.quarkusBranch)
 fi
+# we assume that the issue repository doesn't change between alternatives
 ISSUE_REPO=$(yq r ${ECOSYSTEM_CI_REPO_FILE} issues.repo)
 # we assume that this version correct no matter what Quarkus source we checkout
 QUARKUS_VERSION=$(yq r ${ECOSYSTEM_CI_REPO_FILE} quarkus.version)
-# this will only be used if QUARKUS_BRANCH is not set
-QUARKUS_SHA=$(yq r ${ECOSYSTEM_CI_REPO_FILE} quarkus.sha)
 cd - > /dev/null
 
 # Checkout Quarkus

--- a/setup-and-test
+++ b/setup-and-test
@@ -2,26 +2,38 @@
 set -e
 
 cd ecosystem-ci/${ECOSYSTEM_CI_REPO_PATH}
-ISSUE_NUM=$(yq r ${ECOSYSTEM_CI_REPO_FILE} issues.latestCommit)
+# if ISSUE_NUM was not specified, read it from the context file
+if [[ -z "${ISSUE_NUM}" ]]; then
+  ISSUE_NUM=$(yq r ${ECOSYSTEM_CI_REPO_FILE} issues.latestCommit)
+fi
 ISSUE_REPO=$(yq r ${ECOSYSTEM_CI_REPO_FILE} issues.repo)
+# we assume that this version correct no matter what Quarkus source we checkout
 QUARKUS_VERSION=$(yq r ${ECOSYSTEM_CI_REPO_FILE} quarkus.version)
+# this will only be used if QUARKUS_BRANCH is not set
 QUARKUS_SHA=$(yq r ${ECOSYSTEM_CI_REPO_FILE} quarkus.sha)
 cd - > /dev/null
 
+# Checkout Quarkus
+if [[ -z "${QUARKUS_BRANCH}" ]]; then
+  # a depth of 1 should be fine because this runs almost as soon as the original value of QUARKUS_SHA was created,
+  # but lets be on the safe side by pulling in some more history
+  git clone --depth=20 --branch master https://github.com/quarkusio/quarkus.git
+  cd quarkus
+  git checkout ${QUARKUS_SHA}
+else
+  # if a branch was specified, then just check that out
+  git clone --depth=1 --branch ${QUARKUS_BRANCH} https://github.com/quarkusio/quarkus.git
+  cd quarkus
+fi
+
 # Build Quarkus
-
-# a depth of 1 should be fine because this runs almost as soon as the original value of QUARKUS_SHA was created,
-# but lets be on the safe side by pulling in some more history
-git clone --depth=20 --branch master https://github.com/quarkusio/quarkus.git
-cd quarkus
-git checkout ${QUARKUS_SHA}
-
-# perform the actual build
 ./mvnw -B clean install -DskipTests -DskipITs -DskipDocs
 
 cd - > /dev/null
 
-# perform actual test run
+# delete the quarkus repository in order to allow multiple consecutive executions of this script
+rm -rf quarkus
+
 cd current-repo
 
 # check the test script
@@ -48,6 +60,7 @@ else
     cp ../ecosystem-ci/quarkus-ecosystem-maven-settings.xml .github/quarkus-ecosystem-maven-settings.xml
 fi
 
+# perform actual test run
 if QUARKUS_VERSION=${QUARKUS_VERSION} .github/quarkus-ecosystem-test ; then
   echo "Tests succeeded"
   TEST_STATUS="success"


### PR DESCRIPTION
The idea is to make it simple to allow an ecosystem CI run to test different Quarkus versions.

For example Kogito's GH Actions definition (at https://github.com/kiegroup/kogito-runtimes/blob/master/.github/workflows/quarkus-snapshot.yaml) could be changed to:

```yaml
name: "Quarkus ecosystem CI"
on:
  watch:
    types: [started]

  # For this CI to work, ECOSYSTEM_CI_TOKEN needs to contain a GitHub with rights to close the Quarkus issue that the user/bot has opened,
  # while 'ECOSYSTEM_CI_REPO_PATH' needs to be set to the corresponding path in the 'quarkusio/quarkus-ecosystem-ci' repository

env:
  ECOSYSTEM_CI_REPO: quarkusio/quarkus-ecosystem-ci
  ECOSYSTEM_CI_REPO_FILE: context.yaml
  JAVA_VERSION: 11

  #########################
  # Repo specific setting #
  #########################

  ECOSYSTEM_CI_REPO_PATH:  kogito-quarkus

jobs:
  quarkus-master:
    name: "Build against latest Quarkus snapshot"
    runs-on: ubuntu-latest
    if: github.actor == 'quarkusbot'

    steps:
      - name: Install yq
        run: sudo add-apt-repository ppa:rmescandon/yq && sudo apt update && sudo apt install yq -y

      - name: Set up Java
        uses: actions/setup-java@v1
        with:
          java-version: ${{ env.JAVA_VERSION }}

      - name: Checkout repo
        uses: actions/checkout@v2
        with:
          path: current-repo
          ref: master

      - name: Checkout Ecosystem
        uses: actions/checkout@v2
        with:
          repository: ${{ env.ECOSYSTEM_CI_REPO }}
          ref: master
          path: ecosystem-ci

      - name: Test against Quarkus master
        run: ./ecosystem-ci/setup-and-test
        env:
          ECOSYSTEM_CI_TOKEN: ${{ secrets.ECOSYSTEM_CI_TOKEN }}

  quarkus-lts:
    name: "Build against latest Quarkus LTS"
    runs-on: ubuntu-latest
    if: github.actor == 'quarkusbot'

    steps:
      - name: Install yq
        run: sudo add-apt-repository ppa:rmescandon/yq && sudo apt update && sudo apt install yq -y

      - name: Set up Java
        uses: actions/setup-java@v1
        with:
          java-version: ${{ env.JAVA_VERSION }}

      - name: Checkout repo
        uses: actions/checkout@v2
        with:
          path: current-repo
          ref: master

      - name: Checkout Ecosystem
        uses: actions/checkout@v2
        with:
          repository: ${{ env.ECOSYSTEM_CI_REPO }}
          ref: master
          path: ecosystem-ci

      - name: Test against Quarkus master
        run: ./ecosystem-ci/setup-and-test
        env:
          ECOSYSTEM_CI_TOKEN: ${{ secrets.ECOSYSTEM_CI_TOKEN }}
          ISSUE_NUM=9999 #needs to be created
          QUARKUS_BRANCH=1.11

```

Basically this adds a second job to be run on the same trigger, but configured the `setup-and-test` script by overriding the issue number and quarkus branch name.
Setup could potentially be different, but I show the 2 jobs approach here since we want the test to run for both Quarkus branches whether or not either fails