### PR TITLE
KOGITO-4347 Setup check against Quarkus LTS

### DIFF
--- a/kogito-quarkus/info.yaml
+++ b/kogito-quarkus/info.yaml
@@ -2,3 +2,7 @@ url: https://github.com/kiegroup/kogito-runtimes # Github repo of your extension
 issues:
   repo: quarkusio/quarkus # this should be left as is when CI updates are going to be reported on the Quarkus repository
   latestCommit: 12486 # this is the number of the issue you created above
+alternatives:
+  lts:
+    issue: XXXX # some new issue number
+    quarkusBranch: 1.11

--- a/kogito-quarkus/info.yaml
+++ b/kogito-quarkus/info.yaml
@@ -1,8 +1,8 @@
 url: https://github.com/kiegroup/kogito-runtimes # Github repo of your extension
 issues:
   repo: quarkusio/quarkus # this should be left as is when CI updates are going to be reported on the Quarkus repository
-  latestCommit: 12486 # this is the number of the issue you created above
+  latestCommit: 12486 # this is the number of the issue for master check
 alternatives:
   lts:
-    issue: XXXX # some new issue number
+    issue: 14791 # this is the number of the issue for LTS check
     quarkusBranch: 1.11


### PR DESCRIPTION
Following https://github.com/quarkusio/quarkus-ecosystem-ci/pull/38/files, here the configuration for LTS check for Kogito.

KOGITO PR: https://github.com/kiegroup/kogito-runtimes/pull/1033