### PR TITLE
Update Quarkus version in pom files

### DIFF
--- a/quarkus-ecosystem-test
+++ b/quarkus-ecosystem-test
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B clean install -Dquarkus.version=${QUARKUS_VERSION} -Dversion.io.quarkus=${QUARKUS_VERSION} -Dnative -Dquarkus.native.container-build=true
+# update the versions
+mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set-property -Dproperty=quarkus.version -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
+mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set-property -Dproperty=version.io.quarkus -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
+
+# run the tests
+mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B clean install -Dnative -Dquarkus.native.container-build=true


### PR DESCRIPTION
Relying on system properties is a bad idea when using the invoker
plugin, it leads to all kinds of inconsistency that we had to fix for
the Platform and Kogito.

Update the versions in the pom files is much safer