### PR TITLE
Provide new issue number for Quarkus Test Suite

### DIFF
--- a/quarkus-qe-ts/info.yaml
+++ b/quarkus-qe-ts/info.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/quarkus-qe/quarkus-test-suite
 issues:
   repo: quarkusio/quarkus
-  latestCommit: 19125
+  latestCommit: 19500


### PR DESCRIPTION
Provide a new issue number https://github.com/quarkusio/quarkus/issues/19500 to link the repository with.
The previous issue number was created by me and hence the issue status can't be updated using the QuarkusQE user (the one with our CI token).