### PR TITLE
Introduce Quarkus Jackson JQ extension to CI

### DIFF
--- a/quarkiverse-jackson-jq/info.yaml
+++ b/quarkiverse-jackson-jq/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/quarkiverse/quarkus-jackson-jq
+issues:
+  repo: quarkusio/quarkus
+  latestCommit: 46


### PR DESCRIPTION
Adding [quarkus-jackson-jq](https://github.com/quarkiverse/quarkus-jackson-jq) extension to the CI.