### PR TITLE
Revert "Disable until next LTS version of Quarkus is out"

### DIFF
--- a/kogito-quarkus/info.yaml
+++ b/kogito-quarkus/info.yaml
@@ -2,7 +2,7 @@ url: https://github.com/kiegroup/kogito-runtimes # Github repo of your extension
 issues:
   repo: quarkusio/quarkus # this should be left as is when CI updates are going to be reported on the Quarkus repository
   latestCommit: 12486 # this is the number of the issue for main check
-# alternatives:
-#   lts:
-#     issue: 14860 # this is the number of the issue for LTS check
-#     quarkusBranch: 2.7
+alternatives:
+  lts:
+    issue: 14860 # this is the number of the issue for LTS check
+    quarkusBranch: 2.7


### PR DESCRIPTION
Reverts quarkusio/quarkus-ecosystem-ci#94

@geoand sorry there was a misunderstanding on our side ...
We may disable it but later when we know exactly when we will be able to change quarkus LTS version