### PR TITLE
Upgrade GitHub API to 1.308

### DIFF
--- a/quarkus-ecosystem-issue.java
+++ b/quarkus-ecosystem-issue.java
@@ -16,7 +16,7 @@
 
 //usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS org.kohsuke:github-api:1.101
+//DEPS org.kohsuke:github-api:1.308
 //DEPS info.picocli:picocli:4.2.0
 
 import org.kohsuke.github.*;


### PR DESCRIPTION
Old version was not compatible with Java 17 and we have some members moving to it, even if not recommended.