### PR TITLE
Enable ecosystem CI for OptaPlanner quickstarts

### DIFF
--- a/optaplanner-quickstarts/info.yaml
+++ b/optaplanner-quickstarts/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/kiegroup/optaplanner-quickstarts
+issues:
+  repo: quarkusio/quarkus
+  latestCommit: 11563


### PR DESCRIPTION
Although the [OptaPlanner Quickstarts](https://github.com/kiegroup/optaplanner-quickstarts) repository itself does not contain any Quarkus extension, it provides essential test coverage of the [OptaPlanner Quarkus extensions](https://github.com/kiegroup/optaplanner/tree/main/optaplanner-quarkus-integration).

Is there any better way of enabling the ecosystem CI for several repositories? E.g. by providing multiple URLs in the [optaplanner/info.yaml](https://github.com/quarkusio/quarkus-ecosystem-ci/blob/main/optaplanner/info.yaml) instead of creating a new folder as I do.

Relates to https://github.com/kiegroup/optaplanner-quickstarts/pull/406.