### PR TITLE
Introduce 3.0 alternative for quarkus-prettytime

### DIFF
--- a/quarkiverse-prettytime/info.yaml
+++ b/quarkiverse-prettytime/info.yaml
@@ -2,3 +2,7 @@ url: https://github.com/quarkiverse/quarkus-prettytime
 issues:
   repo: quarkiverse/quarkiverse
   latestCommit: 33
+alternatives:
+  "3.0":
+    issue: "33"
+    quarkusBranch: "3.0"

--- a/setup-and-test
+++ b/setup-and-test
@@ -7,8 +7,8 @@ if [[ -z "${ALTERNATIVE}" ]]; then
   ISSUE_NUM=$(yq e '.issues.latestCommit' ${ECOSYSTEM_CI_REPO_FILE})
   QUARKUS_SHA=$(yq e '.quarkus.sha' ${ECOSYSTEM_CI_REPO_FILE})
 else
-  ISSUE_NUM=$(yq e ".alternatives.${ALTERNATIVE}.issue" ${ECOSYSTEM_CI_REPO_FILE})
-  QUARKUS_BRANCH=$(yq e ".alternatives.${ALTERNATIVE}.quarkusBranch" ${ECOSYSTEM_CI_REPO_FILE})
+  ISSUE_NUM=$(yq e ".alternatives.\"${ALTERNATIVE}\".issue" ${ECOSYSTEM_CI_REPO_FILE})
+  QUARKUS_BRANCH=$(yq e ".alternatives.\"${ALTERNATIVE}\".quarkusBranch" ${ECOSYSTEM_CI_REPO_FILE})
 fi
 # we assume that the issue repository doesn't change between alternatives
 ISSUE_REPO=$(yq e '.issues.repo' ${ECOSYSTEM_CI_REPO_FILE})


### PR DESCRIPTION
Experimenting with 3.0 as an alternative build.

I've set https://github.com/quarkiverse/quarkus-prettytime/blob/main/.github/workflows/quarkus-snapshot.yaml#L14 