### PR TITLE
Add injectible env vars

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -74,6 +74,20 @@ env:
 
   ECOSYSTEM_CI_REPO_PATH: FIXME # TODO: this needs to be set to the directory name added in 'quarkusio/quarkus-ecosystem-ci'
 
+  ###################################
+  # Optional repo specific settings #
+  ###################################
+
+  # The setup-and-test script assumes the pom.xml file is at the root of your repo
+  # Use this env var to add a nested path within your repo where pom.xml is
+  QUARKUS_VERSION_POM_PATH: PATH_WHERE_POM_XML_IS  
+
+  # The setup-and-test script assumes the property within pom.xml that determines the
+  # quarkus version is called "quarkus.version".
+  # Use this env var to override the property to something else
+  # (like "quarkus.platform.version" for example)
+  QUARKUS_VERSION_POM_PROPERTY: quarkus.version
+
 jobs:
   build:
     name: "Build against latest Quarkus snapshot"

--- a/setup-and-test
+++ b/setup-and-test
@@ -9,7 +9,18 @@ if [[ -z "${ALTERNATIVE}" ]]; then
   QUARKUS_VERSION=$(yq e '.quarkus.version' ${ECOSYSTEM_CI_REPO_FILE})
 
   # Detect if Quarkus 2.x is used and point to the correct branch
-  if [[ "$(mvn help:evaluate -Dexpression=quarkus.version -q -DforceStdout -f ../../current-repo/pom.xml| cut -d. -f1)" = "2" ]]; then
+  REPO_PATH=../../current-repo
+  POM_PROPERTY=quarkus.version
+
+  if [[ ! -z "${QUARKUS_VERSION_POM_PATH}" ]]; then
+    REPO_PATH="${REPO_PATH}/${QUARKUS_VERSION_POM_PATH}"
+  fi
+
+  if [[ ! -z "${QUARKUS_VERSION_POM_PROPERTY}" ]]; then
+    POM_PROPERTY=${QUARKUS_VERSION_POM_PROPERTY}
+  fi
+
+  if [[ "$(mvn help:evaluate -Dexpression=${POM_PROPERTY} -q -DforceStdout -f ${REPO_PATH}/pom.xml| cut -d. -f1)" = "2" ]]; then
       QUARKUS_BRANCH="2.16"
       QUARKUS_VERSION="2.16.999-SNAPSHOT"
   fi


### PR DESCRIPTION
Add some injectible environment variables into the script to allow projects to override the location of pom.xml within the project as well as the property name within pom.xml to read the Quarkus version from.

See https://github.com/quarkusio/quarkus/issues/23612#issuecomment-1419105986 for details