### PR TITLE
Pass QUARKUS_VERSION into ci-init script

### DIFF
--- a/setup-and-test
+++ b/setup-and-test
@@ -101,7 +101,7 @@ fi
 
 # check custom init
 if [ -f .github/ci-init.sh ]; then
-  if .github/ci-init.sh ; then
+  if QUARKUS_VERSION=${QUARKUS_VERSION} .github/ci-init.sh ; then
     echo "Custom init script done"
   fi
 fi


### PR DESCRIPTION
Analogous to the test script.

Follow-up to https://github.com/quarkusio/quarkus-ecosystem-ci/pull/140.