### PR TITLE
Fix issue number for the JDBC Clickhouse extension

### DIFF
--- a/quarkiverse-jdbc-clickhouse/info.yaml
+++ b/quarkiverse-jdbc-clickhouse/info.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/quarkiverse/quarkus-jdbc-clickhouse
 issues:
   repo: quarkiverse/quarkiverse
-  latestCommit: 72
+  latestCommit: 194


### PR DESCRIPTION
The info seems to have been copied from the Couchbase extension