### PR TITLE
Fix path to report script when building Quarkus

### DIFF
--- a/setup-and-test
+++ b/setup-and-test
@@ -76,7 +76,7 @@ if ./mvnw -B clean install -DskipTests -DskipITs -DskipDocs -Prelocations ; then
   echo "Quarkus built successfully"
 else
   echo "Failed to build Quarkus"
-  jbang .github/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="failure" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}"
+  jbang ../ecosystem-ci/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="failure" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}"
   exit 1
 fi
 


### PR DESCRIPTION
Should fix:
Failed to build Quarkus
Error:  [ERROR] Script or alias could not be found or read: '.github/quarkus-ecosystem-issue.java'

@geoand and @gastaldi could you have a look at that?

The problem is that at this stage, we haven't copied the custom script that is copied from ecosystem ci to .github/ of the tested project.

Ideally, I suppose we should copy the custom script early but I didn't want to break something else. Feel free to do better :).
