### PR TITLE
Use -Dquickly to build Quarkus

### DIFF
--- a/setup-and-test
+++ b/setup-and-test
@@ -72,7 +72,7 @@ sdk install jbang 0.110.1
 
 
 echo "Building Quarkus"
-if ./mvnw -B clean install -DskipTests -DskipITs -DskipDocs -Prelocations ; then
+if ./mvnw -B clean install -Dquickly -Prelocations ; then
   echo "Quarkus built successfully"
 else
   echo "Failed to build Quarkus"


### PR DESCRIPTION
This is to leverage https://github.com/quarkusio/quarkus/pull/38278 and any improvement we would do there.

The main rationale is that we had Ecosystem CI failures tonight because badssl.com was too slow or had an outage.