### PR TITLE
[quarkus-super-heroes] -Add 3.14.x alternative

### DIFF
--- a/quarkus-super-heroes/context.yaml
+++ b/quarkus-super-heroes/context.yaml
@@ -6,4 +6,6 @@ quarkus:
   version: 999-SNAPSHOT
   sha: 586592e86f2eb96088d2b6c7f99460ab5dcb7c3a
 alternatives:
-  null
+  3.14.x:
+    issue: "23612"
+    quarkusBranch: "3.15"


### PR DESCRIPTION
Add a 3.14.x alternative. Should fix https://github.com/quarkusio/quarkus/issues/23612#issuecomment-2340701670 for now until 3.15 is out.