### PR TITLE
3.14.x alternative for super heroes

### DIFF
--- a/quarkus-super-heroes/context.yaml
+++ b/quarkus-super-heroes/context.yaml
@@ -6,4 +6,6 @@ quarkus:
   version: 999-SNAPSHOT
   sha: 1c8464b3ff87a75857bc1a8a9f0e8a72db584d58
 alternatives:
-  null
+  3.14.x:
+    issue: "23612"
+    quarkusBranch: "3.15"

--- a/quarkus-super-heroes/info.yaml
+++ b/quarkus-super-heroes/info.yaml
@@ -2,3 +2,7 @@ url: https://github.com/quarkusio/quarkus-super-heroes
 issues:
   repo: quarkusio/quarkus
   latestCommit: 23612
+alternatives:
+  3.14.x:
+    issue: "23612"
+    quarkusBranch: "3.15"


### PR DESCRIPTION
Follow-up to #161 . I didn't realize you also needed to update `info.yaml`, otherwise `context.yaml` gets overridden.