### PR TITLE
Use pre-built Quarkus snapshots instead of building from source

### DIFF
--- a/ci-prerequisites.sh
+++ b/ci-prerequisites.sh
@@ -1,4 +1,3 @@
 # Reclaim disk space
-time docker rmi node:10 node:12 mcr.microsoft.com/azure-pipelines/node8-typescript:latest
 time sudo rm -rf /usr/share/dotnet
 time sudo rm -rf /usr/share/swift

--- a/quarkus-ecosystem-issue.java
+++ b/quarkus-ecosystem-issue.java
@@ -63,6 +63,15 @@ class Report implements Runnable {
 	@Option(names = "projectSha", description = "The Git sha of the current project under test")
 	private String projectSha;
 
+	@Option(names = "builtFromSource", description = "Whether Quarkus was built from source instead of using a pre-built snapshot")
+	private boolean builtFromSource;
+
+	@Option(names = "quarkusBranch", description = "The Quarkus branch used for the build")
+	private String quarkusBranch;
+
+	@Option(names = "quarkusVersion", description = "The Quarkus version used for the build")
+	private String quarkusVersion;
+
 	@Override
 	public void run() {
 		try {
@@ -73,6 +82,10 @@ class Report implements Runnable {
 			}
 
 			System.out.println(String.format("The CI build had status %s.", status));
+
+			final String buildNote = builtFromSource
+					? String.format("\n* **Note:** Quarkus was built from source (branch: `%s`, version: `%s`)", quarkusBranch, quarkusVersion)
+					: "";
 
 			final GitHub github = new GitHubBuilder().withOAuthToken(token).build();
 			final GHRepository repository = github.getRepository(issueRepo);
@@ -100,7 +113,7 @@ class Report implements Runnable {
 
 				if (isOpen(issue)) {
 					// close issue with a comment
-					final GHIssueComment comment = issue.comment(String.format("Build fixed:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s", thisRepo, runId));
+					final GHIssueComment comment = issue.comment(String.format("Build fixed:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s%s", thisRepo, runId, buildNote));
 					issue.close();
 					System.out.println(String.format("Comment added on issue %s - %s, the issue has also been closed", issue.getHtmlUrl().toString(), comment.getHtmlUrl().toString()));
 				} else {
@@ -111,14 +124,14 @@ class Report implements Runnable {
 				lastFailure = newState;
 
 				if (isOpen(issue)) {
-					final GHIssueComment comment = issue.comment(String.format("The build is still failing:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s", thisRepo, runId));
+					final GHIssueComment comment = issue.comment(String.format("The build is still failing:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s%s", thisRepo, runId, buildNote));
 					System.out.println(String.format("Comment added on issue %s - %s", issue.getHtmlUrl().toString(), comment.getHtmlUrl().toString()));
 
 					// for old reports, we won't have the first failure previously set so let's set it to the new state as an approximation
 					firstFailure = existingStatus.firstFailure() != null ? State.KEEP_EXISTING : newState;
 				} else {
 					issue.reopen();
-					final GHIssueComment comment = issue.comment(String.format("Unfortunately, the build failed:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s", thisRepo, runId));
+					final GHIssueComment comment = issue.comment(String.format("Unfortunately, the build failed:\n* Link to latest CI run: https://github.com/%s/actions/runs/%s%s", thisRepo, runId, buildNote));
 					System.out.println(String.format("Comment added on issue %s - %s, the issue has been re-opened", issue.getHtmlUrl().toString(), comment.getHtmlUrl().toString()));
 
 					firstFailure = newState;

--- a/quarkus-ecosystem-maven-settings.xml
+++ b/quarkus-ecosystem-maven-settings.xml
@@ -33,35 +33,5 @@
 				</pluginRepository>
 			</pluginRepositories>
 		</profile>
-		<profile>
-			<id>snapshots</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<repositories>
-				<repository>
-					<id>snapshots-repo</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-					<releases>
-						<enabled>false</enabled>
-					</releases>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</repository>
-			</repositories>
-			<pluginRepositories>
-				<pluginRepository>
-					<id>snapshots-repo</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-					<releases>
-						<enabled>false</enabled>
-					</releases>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</pluginRepository>
-			</pluginRepositories>
-		</profile>
 	</profiles>
 </settings>

--- a/quarkus-ecosystem-test
+++ b/quarkus-ecosystem-test
@@ -2,8 +2,8 @@
 set -e
 
 # update the versions
-mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set-property -Dproperty=quarkus.version -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
-mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set-property -Dproperty=version.io.quarkus -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
+mvn -nsu --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set-property -Dproperty=quarkus.version -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
+mvn -nsu --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set-property -Dproperty=version.io.quarkus -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
 
 # run the tests
-mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B clean install -Dnative -Dquarkus.native.container-build=true --fail-at-end -e
+mvn -nsu --settings .github/quarkus-ecosystem-maven-settings.xml -B clean install -Dnative -Dquarkus.native.container-build=true --fail-at-end -e

--- a/setup-and-test
+++ b/setup-and-test
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -x -e
+set -e
 
 cd ecosystem-ci/${ECOSYSTEM_CI_REPO_PATH}
 # if an alternative is not specified, then we just read the global info

--- a/setup-and-test
+++ b/setup-and-test
@@ -33,8 +33,39 @@ sed -i -e 's/sdkman_auto_answer=false/sdkman_auto_answer=true/g' ~/.sdkman/etc/c
 echo "Installing jbang"
 sdk install jbang 0.126.3
 
-# Install Quarkus snapshot from pre-built release
-ecosystem-ci/setup-quarkus "${QUARKUS_BRANCH:-main}"
+# Install Quarkus snapshot from pre-built release, fall back to building from source
+if ecosystem-ci/setup-quarkus "${QUARKUS_BRANCH:-main}"; then
+  echo "Quarkus snapshot installed from pre-built release"
+else
+  echo "Pre-built release not available, building Quarkus from source"
+
+  # Checkout Quarkus
+  if [[ -z "${QUARKUS_BRANCH}" ]]; then
+    git clone --depth=20 --branch main https://github.com/quarkusio/quarkus.git
+    cd quarkus
+    git checkout ${QUARKUS_SHA}
+  else
+    git clone --depth=1 --branch ${QUARKUS_BRANCH} https://github.com/quarkusio/quarkus.git
+    cd quarkus
+  fi
+
+  QUARKUS_SHA=$(git rev-parse HEAD)
+  if [[ -z "${QUARKUS_VERSION}" ]]; then
+    QUARKUS_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+  fi
+
+  echo "Building Quarkus"
+  if ./mvnw -B clean install -Dquickly -Prelocations -Dno-test-modules; then
+    echo "Quarkus built successfully"
+  else
+    echo "Failed to build Quarkus"
+    jbang ecosystem-ci/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="failure" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}"
+    exit 1
+  fi
+
+  cd - > /dev/null
+  rm -rf quarkus
+fi
 
 echo "Quarkus Version is: ${QUARKUS_VERSION}"
 

--- a/setup-and-test
+++ b/setup-and-test
@@ -36,6 +36,7 @@ sdk install jbang 0.126.3
 # Install Quarkus snapshot from pre-built release, fall back to building from source
 if ecosystem-ci/setup-quarkus "${QUARKUS_BRANCH:-main}"; then
   echo "Quarkus snapshot installed from pre-built release"
+  source /tmp/quarkus-env
   QUARKUS_BUILT_FROM_SOURCE="false"
 else
   echo "Pre-built release not available, building Quarkus from source"

--- a/setup-and-test
+++ b/setup-and-test
@@ -25,11 +25,16 @@ cd - > /dev/null
 # Export variables needed by setup-quarkus for failure reporting
 export ISSUE_REPO ISSUE_NUM QUARKUS_SHA
 
+echo "Installing SDKMAN"
+curl -s "https://get.sdkman.io" | bash
+source ~/.sdkman/bin/sdkman-init.sh
+sed -i -e 's/sdkman_auto_answer=false/sdkman_auto_answer=true/g' ~/.sdkman/etc/config
+
+echo "Installing jbang"
+sdk install jbang 0.126.3
+
 # Install Quarkus snapshot from pre-built release
 ecosystem-ci/setup-quarkus "${QUARKUS_BRANCH:-main}"
-
-# Source SDKMAN so jbang is available for the rest of the script
-source ~/.sdkman/bin/sdkman-init.sh
 
 echo "Quarkus Version is: ${QUARKUS_VERSION}"
 

--- a/setup-and-test
+++ b/setup-and-test
@@ -7,23 +7,6 @@ if [[ -z "${ALTERNATIVE}" ]]; then
   ISSUE_NUM=$(yq e '.issues.latestCommit' ${ECOSYSTEM_CI_REPO_FILE})
   QUARKUS_SHA=$(yq e '.quarkus.sha' ${ECOSYSTEM_CI_REPO_FILE})
   QUARKUS_VERSION=$(yq e '.quarkus.version' ${ECOSYSTEM_CI_REPO_FILE})
-
-  # Detect if Quarkus 2.x is used and point to the correct branch
-  REPO_PATH=../../current-repo
-  POM_PROPERTY=quarkus.version
-
-  if [[ ! -z "${QUARKUS_VERSION_POM_PATH}" ]]; then
-    REPO_PATH="${REPO_PATH}/${QUARKUS_VERSION_POM_PATH}"
-  fi
-
-  if [[ ! -z "${QUARKUS_VERSION_POM_PROPERTY}" ]]; then
-    POM_PROPERTY=${QUARKUS_VERSION_POM_PROPERTY}
-  fi
-
-  if [[ "$(mvn help:evaluate -Dexpression=${POM_PROPERTY} -q -DforceStdout -f ${REPO_PATH}/pom.xml| cut -d. -f1)" = "2" ]]; then
-      QUARKUS_BRANCH="2.16"
-      QUARKUS_VERSION="2.16.999-SNAPSHOT"
-  fi
 else
   # Check if the alternative exists
   if [[ "$(yq e '.alternatives|has(env(ALTERNATIVE))' ${ECOSYSTEM_CI_REPO_FILE})" ]] ; then
@@ -39,49 +22,16 @@ fi
 ISSUE_REPO=$(yq e '.issues.repo' ${ECOSYSTEM_CI_REPO_FILE})
 cd - > /dev/null
 
-# Checkout Quarkus
-if [[ -z "${QUARKUS_BRANCH}" ]]; then
-  # a depth of 1 should be fine because this runs almost as soon as the original value of QUARKUS_SHA was created,
-  # but lets be on the safe side by pulling in some more history
-  git clone --depth=20 --branch main https://github.com/quarkusio/quarkus.git
-  cd quarkus
-  git checkout ${QUARKUS_SHA}
-else
-  # if a branch was specified, then just check that out
-  git clone --depth=1 --branch ${QUARKUS_BRANCH} https://github.com/quarkusio/quarkus.git
-  cd quarkus
-fi
+# Export variables needed by setup-quarkus for failure reporting
+export ISSUE_REPO ISSUE_NUM QUARKUS_SHA
 
-QUARKUS_SHA=$(git rev-parse HEAD)
-if [[ -z "${QUARKUS_VERSION}" ]]; then
-  # Alternatives may run against a different Quarkus version, so we need to evaluate that
-  QUARKUS_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
-fi
+# Install Quarkus snapshot from pre-built release
+ecosystem-ci/setup-quarkus "${QUARKUS_BRANCH:-main}"
+
+# Source SDKMAN so jbang is available for the rest of the script
+source ~/.sdkman/bin/sdkman-init.sh
 
 echo "Quarkus Version is: ${QUARKUS_VERSION}"
-
-echo "Installing SDKMAN"
-curl -s "https://get.sdkman.io" | bash
-source ~/.sdkman/bin/sdkman-init.sh
-sed -i -e 's/sdkman_auto_answer=false/sdkman_auto_answer=true/g' ~/.sdkman/etc/config
-
-echo "Installing jbang"
-sdk install jbang 0.126.3
-
-
-echo "Building Quarkus"
-if ./mvnw -B clean install -Dquickly -Prelocations -Dno-test-modules; then
-  echo "Quarkus built successfully"
-else
-  echo "Failed to build Quarkus"
-  jbang ../ecosystem-ci/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="failure" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}"
-  exit 1
-fi
-
-cd - > /dev/null
-
-# delete the quarkus repository in order to allow multiple consecutive executions of this script
-rm -rf quarkus
 
 cd current-repo
 PROJECT_SHA=$(git rev-parse HEAD)

--- a/setup-and-test
+++ b/setup-and-test
@@ -88,6 +88,9 @@ else
   TEST_STATUS="failure"
 fi
 
+echo "Deleting SNAPSHOT artifacts from local Maven repository to save space"
+find ~/.m2 -name \*-SNAPSHOT -type d -exec rm -rf {} +
+
 echo "Attempting to report results"
 
 jbang .github/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="${TEST_STATUS}" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}" projectSha="${PROJECT_SHA}"

--- a/setup-and-test
+++ b/setup-and-test
@@ -36,6 +36,7 @@ sdk install jbang 0.126.3
 # Install Quarkus snapshot from pre-built release, fall back to building from source
 if ecosystem-ci/setup-quarkus "${QUARKUS_BRANCH:-main}"; then
   echo "Quarkus snapshot installed from pre-built release"
+  QUARKUS_BUILT_FROM_SOURCE="false"
 else
   echo "Pre-built release not available, building Quarkus from source"
 
@@ -54,12 +55,14 @@ else
     QUARKUS_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
   fi
 
+  QUARKUS_BUILT_FROM_SOURCE="true"
+
   echo "Building Quarkus"
   if ./mvnw -B clean install -Dquickly -Prelocations -Dno-test-modules; then
     echo "Quarkus built successfully"
   else
     echo "Failed to build Quarkus"
-    jbang ecosystem-ci/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="failure" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}"
+    jbang ecosystem-ci/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="failure" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}" builtFromSource="${QUARKUS_BUILT_FROM_SOURCE}" quarkusBranch="${QUARKUS_BRANCH:-main}" quarkusVersion="${QUARKUS_VERSION}"
     exit 1
   fi
 
@@ -129,7 +132,7 @@ find ~/.m2 -name \*-SNAPSHOT -type d -exec rm -rf {} +
 
 echo "Attempting to report results"
 
-jbang .github/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="${TEST_STATUS}" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}" projectSha="${PROJECT_SHA}"
+jbang .github/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="${TEST_STATUS}" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}" projectSha="${PROJECT_SHA}" builtFromSource="${QUARKUS_BUILT_FROM_SOURCE}" quarkusBranch="${QUARKUS_BRANCH:-main}" quarkusVersion="${QUARKUS_VERSION}"
 
 echo "Report completed"
 

--- a/setup-quarkus
+++ b/setup-quarkus
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -x -e
+set -e
 
 QUARKUS_SNAPSHOT_BRANCH="${1:-main}"
 QUARKUS_SNAPSHOT_REPO="quarkusio/quarkus-ecosystem-ci"

--- a/setup-quarkus
+++ b/setup-quarkus
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -x -e
+
+QUARKUS_SNAPSHOT_BRANCH="${1:-main}"
+QUARKUS_SNAPSHOT_REPO="quarkusio/quarkus-ecosystem-ci"
+PREFIX="maven-repo-${QUARKUS_SNAPSHOT_BRANCH}-"
+
+echo "Installing SDKMAN"
+curl -s "https://get.sdkman.io" | bash
+source ~/.sdkman/bin/sdkman-init.sh
+sed -i -e 's/sdkman_auto_answer=false/sdkman_auto_answer=true/g' ~/.sdkman/etc/config
+
+echo "Installing jbang"
+sdk install jbang 0.126.3
+
+report_failure() {
+  echo "Failed to install Quarkus snapshot"
+  jbang ecosystem-ci/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="failure" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}"
+  exit 1
+}
+
+echo "Looking for latest Quarkus snapshot release for branch: ${QUARKUS_SNAPSHOT_BRANCH}"
+
+RELEASE_INFO=$(gh release list --limit 20 \
+  --repo "${QUARKUS_SNAPSHOT_REPO}" \
+  | grep "${PREFIX}" \
+  | head -n 1)
+
+if [ -z "${RELEASE_INFO}" ]; then
+  echo "No snapshot release found for branch '${QUARKUS_SNAPSHOT_BRANCH}'"
+  report_failure
+fi
+
+TAG=$(echo "${RELEASE_INFO}" | awk -F'\t' '{print $3}')
+PUBLISHED=$(echo "${RELEASE_INFO}" | awk -F'\t' '{print $4}')
+
+echo "Found release: ${TAG} (published: ${PUBLISHED})"
+
+# Check if the release is older than 36 hours
+RELEASE_EPOCH=$(date -d "${PUBLISHED}" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "${PUBLISHED}" +%s 2>/dev/null)
+NOW_EPOCH=$(date +%s)
+AGE_HOURS=$(( (NOW_EPOCH - RELEASE_EPOCH) / 3600 ))
+
+if [ "${AGE_HOURS}" -gt 36 ]; then
+  echo "Latest snapshot release '${TAG}' is ${AGE_HOURS} hours old (published: ${PUBLISHED}). Expected a release less than 36 hours old."
+  report_failure
+fi
+
+echo "Downloading Quarkus snapshot: ${TAG} (age: ${AGE_HOURS} hours)"
+if ! gh release download "${TAG}" \
+  --repo "${QUARKUS_SNAPSHOT_REPO}" \
+  --pattern "maven-repo.tar.gz" \
+  --dir /tmp; then
+  report_failure
+fi
+
+mkdir -p ~/.m2/repository
+tar -xzf /tmp/maven-repo.tar.gz -C ~/.m2/repository
+rm -f /tmp/maven-repo.tar.gz
+
+echo "Quarkus snapshots for branch '${QUARKUS_SNAPSHOT_BRANCH}' installed successfully."

--- a/setup-quarkus
+++ b/setup-quarkus
@@ -7,7 +7,6 @@ PREFIX="maven-repo-${QUARKUS_SNAPSHOT_BRANCH}-"
 
 report_failure() {
   echo "Failed to install Quarkus snapshot"
-  jbang ecosystem-ci/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="failure" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}"
   exit 1
 }
 

--- a/setup-quarkus
+++ b/setup-quarkus
@@ -5,14 +5,6 @@ QUARKUS_SNAPSHOT_BRANCH="${1:-main}"
 QUARKUS_SNAPSHOT_REPO="quarkusio/quarkus-ecosystem-ci"
 PREFIX="maven-repo-${QUARKUS_SNAPSHOT_BRANCH}-"
 
-echo "Installing SDKMAN"
-curl -s "https://get.sdkman.io" | bash
-source ~/.sdkman/bin/sdkman-init.sh
-sed -i -e 's/sdkman_auto_answer=false/sdkman_auto_answer=true/g' ~/.sdkman/etc/config
-
-echo "Installing jbang"
-sdk install jbang 0.126.3
-
 report_failure() {
   echo "Failed to install Quarkus snapshot"
   jbang ecosystem-ci/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="failure" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}"

--- a/setup-quarkus
+++ b/setup-quarkus
@@ -45,8 +45,11 @@ if ! gh release download "${TAG}" \
   report_failure
 fi
 
+QUARKUS_VERSION=$(tar -tzf /tmp/maven-repo.tar.gz | grep 'io/quarkus/quarkus-core/[^/]' | head -1 | sed 's|.*/quarkus-core/\([^/]*\)/.*|\1|')
+echo "QUARKUS_VERSION=${QUARKUS_VERSION}" > /tmp/quarkus-env
+
 mkdir -p ~/.m2/repository
 tar -xzf /tmp/maven-repo.tar.gz -C ~/.m2/repository
 rm -f /tmp/maven-repo.tar.gz
 
-echo "Quarkus snapshots for branch '${QUARKUS_SNAPSHOT_BRANCH}' installed successfully."
+echo "Quarkus ${QUARKUS_VERSION} for branch '${QUARKUS_SNAPSHOT_BRANCH}' installed successfully."


### PR DESCRIPTION
## Summary

- Replace the clone-and-build-from-source Quarkus workflow with downloading pre-built snapshot artifacts from GitHub releases (`quarkusio/quarkus-ecosystem-ci`), significantly reducing CI build time
- Add new `setup-quarkus` script that finds the latest snapshot release for a given branch, validates its freshness (< 36 hours), and installs it into the local Maven repository
- Remove the Sonatype snapshots profile from Maven settings and add `-nsu` (no snapshot updates) to Maven commands, since dependencies are now resolved locally
- Clean up SNAPSHOT artifacts from `~/.m2` after test runs to save disk space
- Remove obsolete Quarkus 2.x branch detection logic and shell debug tracing

## Test plan

- [x] Verify a CI run successfully downloads and installs the pre-built snapshot
- [x] Confirm tests pass using the pre-built artifacts instead of a from-source build
- [x] Verify failure reporting still works when the snapshot release is missing or stale