### PR TITLE
Handle member errors in launch

### DIFF
--- a/.github/workflows/ecosystem-action.yml
+++ b/.github/workflows/ecosystem-action.yml
@@ -43,7 +43,7 @@ jobs:
           ECOSYSTEM_CI_TOKEN: ${{ secrets.ECOSYSTEM_CI_TOKEN }}
 
       - name: Report failures
-        if: steps.launch.outputs.failed_mem bers != ''
+        if: steps.launch.outputs.failed_members != ''
         uses: actions/github-script@v7
         env:
           FAILED_MEMBERS: ${{ steps.launch.outputs.failed_members }}

--- a/.github/workflows/ecosystem-action.yml
+++ b/.github/workflows/ecosystem-action.yml
@@ -26,8 +26,69 @@ jobs:
           #get the sha or the latest main
           QUARKUS_SHA=$(git ls-remote https://github.com/quarkusio/quarkus main | awk '{print $1;}')
 
+          FAILED_MEMBERS=""
           for member in */ ; do
-              ./run-for-member "${member}" "${QUARKUS_SHA}" "${ECOSYSTEM_CI_TOKEN}"
+              if ! ./run-for-member "${member}" "${QUARKUS_SHA}" "${ECOSYSTEM_CI_TOKEN}"; then
+                echo "::warning::run-for-member failed for ${member}"
+                FAILED_MEMBERS="${FAILED_MEMBERS} ${member}"
+              fi
           done
+
+          if [ -n "${FAILED_MEMBERS}" ]; then
+            echo "The following members failed:${FAILED_MEMBERS}"
+            echo "failed_members=${FAILED_MEMBERS}" >> "$GITHUB_OUTPUT"
+          fi
+        id: launch
         env:
           ECOSYSTEM_CI_TOKEN: ${{ secrets.ECOSYSTEM_CI_TOKEN }}
+
+      - name: Report failures
+        if: steps.launch.outputs.failed_mem bers != ''
+        uses: actions/github-script@v7
+        env:
+          FAILED_MEMBERS: ${{ steps.launch.outputs.failed_members }}
+        with:
+          github-token: ${{ secrets.ECOSYSTEM_CI_TOKEN }}
+          script: |
+            const issueNumber = 216;
+            const owner = 'quarkusio';
+            const repo = 'quarkus-ecosystem-ci';
+            const failedMembers = process.env.FAILED_MEMBERS.trim().split(/\s+/);
+            const body = `The following members failed to have their CI launched during the [workflow run](${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}):\n\n` +
+              failedMembers.map(m => `- \`${m}\``).join('\n') +
+              `\n\nPlease investigate the failures.`;
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              state: 'open'
+            });
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body: body
+            });
+
+      - name: Close issue on success
+        if: steps.launch.outputs.failed_members == ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ECOSYSTEM_CI_TOKEN }}
+          script: |
+            const issueNumber = 216;
+            const owner = 'quarkusio';
+            const repo = 'quarkus-ecosystem-ci';
+            const { data: issue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber
+            });
+            if (issue.state === 'open') {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                state: 'closed'
+              });
+            }


### PR DESCRIPTION
With this change, a single member failure
does not cause the entire loop to fail.
Instead, a new issue is created that contains
all the failed members

N.B. We'll need to create the `ci-failure` label