### PR TITLE
Add quarkus-openapi-generator

### DIFF
--- a/quarkiverse-openapi-generator/info.yaml
+++ b/quarkiverse-openapi-generator/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/quarkiverse/quarkus-openapi-generator
+issues:
+  repo: quarkiverse/quarkiverse
+  latestCommit: 393


### PR DESCRIPTION
Add [quarkus-openapi-generator ](https://github.com/quarkiverse/quarkus-openapi-generator)to Ecosystem CI.