### PR TITLE
Use Europe/Paris as timezone for deploying snapshots

### DIFF
--- a/.github/workflows/deploy-maven-repo.yml
+++ b/.github/workflows/deploy-maven-repo.yml
@@ -6,7 +6,8 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0,12 * * 1-5'
+    - cron: '0 0,12 * * 1-6'
+      timezone: 'Europe/Paris'
 
 env:
   LANG: en_US.UTF-8


### PR DESCRIPTION
It's better to cover most Europe.

Also enable the deployment on Saturdays as I often work on Saturdays.