### PR TITLE
Add alternative to Quarkus Flow (Quarkus 3.33)

### DIFF
--- a/quarkiverse-flow/info.yaml
+++ b/quarkiverse-flow/info.yaml
@@ -2,3 +2,7 @@ url: https://github.com/quarkiverse/quarkus-flow
 issues:
   repo: quarkiverse/quarkiverse
   latestCommit: 359
+alternatives:
+  '3.33':
+    issue: 395
+    quarkusBranch: '3.33'


### PR DESCRIPTION
This pull request add an alternative to Quarkus Flow, now looking the Quarkus 3.33 stream.