### PR TITLE
Add quarkus-multitenancy

### DIFF
--- a/quarkus-multitenancy/info.yaml
+++ b/quarkus-multitenancy/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/quarkiverse/quarkus-multitenancy
+issues:
+  repo: quarkiverse/quarkiverse
+  latestCommit: 396


### PR DESCRIPTION
Hi maintainers,

Adds `quarkus-multitenancy/info.yaml` so the daily Quarkus-snapshot ecosystem CI picks up [quarkiverse/quarkus-multitenancy](https://github.com/quarkiverse/quarkus-multitenancy).

The project is part of the Quarkiverse organization and already has the canonical `.github/workflows/quarkus-snapshot.yaml` wired in (via [quarkiverse/quarkus-multitenancy#6](https://github.com/quarkiverse/quarkus-multitenancy/pull/6)), gated on `quarkusbot` / `quarkiversebot` so it stays a no-op until this registration lands.

Tracking issue: [quarkiverse/quarkiverse#396](https://github.com/quarkiverse/quarkiverse/issues/396)

Thanks for considering!
