### PR TITLE
Add mirror to block external snapshot repositories

### DIFF
--- a/quarkus-ecosystem-maven-settings.xml
+++ b/quarkus-ecosystem-maven-settings.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
+	<mirrors>
+		<mirror>
+			<id>google-maven-central-mirror</id>
+			<name>Google Maven Central Mirror</name>
+			<url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+			<mirrorOf>external:*</mirrorOf>
+		</mirror>
+	</mirrors>
 	<profiles>
 		<profile>
 			<id>google-mirror</id>


### PR DESCRIPTION
The pre-built Quarkus Maven snapshot (tar.gz) is the intended authoritative source of Quarkus artifacts for the ecosystem CI. Because those artifacts have no Maven origin tracking (_remote.repositories), Maven Resolver scans the transitive POM graph for distributionManagement/snapshotRepository entries and uses them as download sources. POMs like netty-bom declare central-portal-snapshots (Sonatype, central.sonatype.com/repository/maven-snapshots), which hosts Quarkus snapshots from before the pre-built tar.gz was assembled. Maven downloads these older artifacts, overriding the correct ones from the tar.gz.

This is failing quarkus-flow ecosystem CI - https://github.com/quarkiverse/quarkus-flow/actions/runs/26859177484/job/79208807817 because of this commit https://github.com/quarkusio/quarkus/commit/8e282144370cbbb1b28c03795cf87dee5bed8418 that moved classes to a different package.

TBH, if this is how ecosystem CI is intended to be running, feel free to discard. But without this, we are pulling older versions of the extension JARs than what the job is intented to be testing.