### PR TITLE
Add quarkus-http-idempotency

### DIFF
--- a/quarkus-http-idempotency/info.yaml
+++ b/quarkus-http-idempotency/info.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/quarkiverse/quarkus-http-idempotency
+issues:
+  repo: quarkiverse/quarkiverse
+  latestCommit: 398


### PR DESCRIPTION
Hi maintainers,

This registers the Quarkiverse extension [`quarkus-http-idempotency`](https://github.com/quarkiverse/quarkus-http-idempotency) for ecosystem CI so it is built against the Quarkus `main` snapshot.

The `quarkus-snapshot.yaml` workflow is already in place on the extension repo, and the tracking issue is quarkiverse/quarkiverse#398.

Thanks!
