### PR TITLE
Change default Quarkus branch to '3.x' in ecosystem CI

### DIFF
--- a/.github/workflows/ecosystem-action.yml
+++ b/.github/workflows/ecosystem-action.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: ecosystem-ci
         run: |
           #get the sha or the latest main
-          QUARKUS_SHA=$(git ls-remote https://github.com/quarkusio/quarkus main | awk '{print $1;}')
+          QUARKUS_SHA=$(git ls-remote https://github.com/quarkusio/quarkus 3.x | awk '{print $1;}')
 
           for member in */ ; do
               ./run-for-member "${member}" "${QUARKUS_SHA}" "${ECOSYSTEM_CI_TOKEN}"

--- a/.github/workflows/ecosystem-member-action.yml
+++ b/.github/workflows/ecosystem-member-action.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: ecosystem-ci
         run: |
           #get the sha or the latest main
-          QUARKUS_SHA=$(git ls-remote https://github.com/quarkusio/quarkus main | awk '{print $1;}')
+          QUARKUS_SHA=$(git ls-remote https://github.com/quarkusio/quarkus 3.x | awk '{print $1;}')
 
           ./run-for-member "${MEMBER}" "${QUARKUS_SHA}" "${ECOSYSTEM_CI_TOKEN}"
         env:

--- a/setup-and-test
+++ b/setup-and-test
@@ -34,7 +34,7 @@ echo "Installing jbang"
 sdk install jbang 0.126.3
 
 # Install Quarkus snapshot from pre-built release, fall back to building from source
-if ecosystem-ci/setup-quarkus "${QUARKUS_BRANCH:-main}"; then
+if ecosystem-ci/setup-quarkus "${QUARKUS_BRANCH:-3.x}"; then
   echo "Quarkus snapshot installed from pre-built release"
   source /tmp/quarkus-env
   QUARKUS_BUILT_FROM_SOURCE="false"
@@ -43,7 +43,7 @@ else
 
   # Checkout Quarkus
   if [[ -z "${QUARKUS_BRANCH}" ]]; then
-    git clone --depth=20 --branch main https://github.com/quarkusio/quarkus.git
+    git clone --depth=20 --branch 3.x https://github.com/quarkusio/quarkus.git
     cd quarkus
     git checkout ${QUARKUS_SHA}
   else
@@ -63,7 +63,7 @@ else
     echo "Quarkus built successfully"
   else
     echo "Failed to build Quarkus"
-    jbang ecosystem-ci/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="failure" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}" builtFromSource="${QUARKUS_BUILT_FROM_SOURCE}" quarkusBranch="${QUARKUS_BRANCH:-main}" quarkusVersion="${QUARKUS_VERSION}"
+    jbang ecosystem-ci/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="failure" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}" builtFromSource="${QUARKUS_BUILT_FROM_SOURCE}" quarkusBranch="${QUARKUS_BRANCH:-3.x}" quarkusVersion="${QUARKUS_VERSION}"
     exit 1
   fi
 
@@ -133,7 +133,7 @@ find ~/.m2 -name \*-SNAPSHOT -type d -exec rm -rf {} +
 
 echo "Attempting to report results"
 
-jbang .github/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="${TEST_STATUS}" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}" projectSha="${PROJECT_SHA}" builtFromSource="${QUARKUS_BUILT_FROM_SOURCE}" quarkusBranch="${QUARKUS_BRANCH:-main}" quarkusVersion="${QUARKUS_VERSION}"
+jbang .github/quarkus-ecosystem-issue.java token="${ECOSYSTEM_CI_TOKEN}" status="${TEST_STATUS}" issueRepo="${ISSUE_REPO}" issueNumber="${ISSUE_NUM}" thisRepo="${GITHUB_REPOSITORY}" runId="${GITHUB_RUN_ID}" quarkusSha="${QUARKUS_SHA}" projectSha="${PROJECT_SHA}" builtFromSource="${QUARKUS_BUILT_FROM_SOURCE}" quarkusBranch="${QUARKUS_BRANCH:-3.x}" quarkusVersion="${QUARKUS_VERSION}"
 
 echo "Report completed"
 


### PR DESCRIPTION
## Summary
- Change the default Quarkus branch from `main` to `3.x` across all ecosystem CI scripts
- Updates `ecosystem-action.yml`, `ecosystem-member-action.yml`, and `setup-and-test`
- `setup-quarkus` already defaults to `3.x`, so no change needed there

## Test plan
- [ ] Trigger a manual ecosystem CI run and verify it fetches the SHA from the `3.x` branch
- [ ] Verify the pre-built snapshot from the `3.x` branch is correctly resolved and installed
- [ ] Confirm issue reporting shows `3.x` as the Quarkus branch