### PR TITLE
Fix incorrect QUARKUS_VERSION when building from 3.x branch

### DIFF
--- a/run-for-member
+++ b/run-for-member
@@ -25,7 +25,6 @@ touch context.yaml
 yq e ".timestamp = \"$(date +'%Y-%m-%d_%H-%M-%S')\"" context.yaml -i
 yq e ".issues.latestCommit = \"${LATEST_COMMIT_ISSUE_NUM}\"" context.yaml -i
 yq e ".issues.repo = \"${ISSUE_REPO}\"" context.yaml -i
-yq e ".quarkus.version = \"999-SNAPSHOT\"" context.yaml -i
 yq e ".quarkus.sha = \"${QUARKUS_SHA}\"" context.yaml -i
 
 # delete previous alternatives

--- a/setup-and-test
+++ b/setup-and-test
@@ -52,9 +52,7 @@ else
   fi
 
   QUARKUS_SHA=$(git rev-parse HEAD)
-  if [[ -z "${QUARKUS_VERSION}" ]]; then
-    QUARKUS_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
-  fi
+  QUARKUS_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
 
   QUARKUS_BUILT_FROM_SOURCE="true"
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `999-SNAPSHOT` version from `run-for-member` — it can't reliably know the version ahead of time since it depends on which branch is built
- Always extract version from Maven when building Quarkus from source, instead of only when `QUARKUS_VERSION` is unset

## Root cause
`run-for-member` hardcoded `999-SNAPSHOT` (the `main` branch version) into every member's `context.yaml`. After #231 changed the default branch to `3.x` (version `3.999-SNAPSHOT`), the build-from-source fallback in `setup-and-test` skipped re-extracting the version because it was already (incorrectly) set from `context.yaml`.

Fixes #232