### PR TITLE
Remove alternatives for version 2.x in info.yaml

### DIFF
--- a/vaadin/info.yaml
+++ b/vaadin/info.yaml
@@ -2,7 +2,3 @@ url: https://github.com/vaadin/quarkus
 issues:
   repo: vaadin/quarkus
   latestCommit: 108
-alternatives:
-    2.x:
-      issue: 109
-      quarkusBranch: "2.16"


### PR DESCRIPTION
Removed alternatives section for version 2.x from info.yaml.

/cc @mcollovati 